### PR TITLE
Hotfix dispose focusNode on dispose state

### DIFF
--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -193,6 +193,12 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
       });
     });
   }
+  
+  @override
+  void dispose() {
+    focusNode?.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This bug produces an error when i ran unit tests and fill some of the textbox (for instance 3/6)

The error when running unit tests is

The following assertion was thrown while dispatching notifications for FocusNode:
setState() called after dispose(): PinCodeTextFieldState#a65d5(lifecycle state: defunct, not
mounted)
This error happens if you call setState() on a State object for a widget that no longer appears in
the widget tree (e.g., whose parent widget no longer includes the widget in its build)