### PR TITLE
support LTR pin code on a RTL layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ import 'package:pin_code_text_field/pin_code_text_field.dart';
 | autofocus | bool | false | Autofocus on view entered |
 | wrapAlignment | WrapAlignment | WrapAlignment.start | Alignment of the wrapped pin boxes |
 | pinCodeTextFieldLayoutType | PinCodeTextFieldLayoutType | PinCodeTextFieldLayoutType.NORMAL | Auto adjust width with `PinCodeTextFieldLayoutType.AUTO_ADJUST_WIDTH`, wrap the pin box row with `PinCodeTextFieldLayoutType.WRAP` |
+| textDirection | TextDirection | TextDirection.ltr | The direction of the pin code |
 
 ## Example
 ```dart

--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -91,6 +91,7 @@ class PinCodeTextField extends StatefulWidget {
   final Duration pinTextAnimatedSwitcherDuration;
   final WrapAlignment wrapAlignment;
   final PinCodeTextFieldLayoutType pinCodeTextFieldLayoutType;
+  final TextDirection textDirection;
 
   const PinCodeTextField({
     Key key,
@@ -116,6 +117,7 @@ class PinCodeTextField extends StatefulWidget {
     this.autofocus: false,
     this.wrapAlignment: WrapAlignment.start,
     this.pinCodeTextFieldLayoutType: PinCodeTextFieldLayoutType.NORMAL,
+    this.textDirection: TextDirection.ltr,
   }) : super(key: key);
 
   @override
@@ -366,6 +368,7 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
             direction: Axis.horizontal,
             alignment: widget.wrapAlignment,
             verticalDirection: VerticalDirection.down,
+            textDirection: widget.textDirection,
             children: pinCodes,
           )
         : Row(
@@ -373,6 +376,7 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
             verticalDirection: VerticalDirection.down,
+            textDirection: widget.textDirection,
             children: pinCodes);
   }
 


### PR DESCRIPTION
Thanks for the great plugin, awesome work!
I am building an app that is RTL, and currently the pin code is RTL as well (because of the layout of the Row).
In this fork, I have added a default of LTR text direction to the Row, which means it will now be LTR by default on RTL apps as well, with the option to control it.