### PR TITLE
Added custom focus node capabilities

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,6 +19,13 @@ class _MyAppState extends State<MyApp> {
   String errorMessage;
 
   @override
+  void dispose() {
+    controller.dispose();
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return isMaterial
         ? new MaterialApp(

--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -87,6 +87,7 @@ class PinCodeTextField extends StatefulWidget {
   final Color hasTextBorderColor;
   final Function(String) onTextChanged;
   final bool autofocus;
+  final FocusNode focusNode;
   final AnimatedSwitcherTransitionBuilder pinTextAnimatedSwitcherTransition;
   final Duration pinTextAnimatedSwitcherDuration;
   final WrapAlignment wrapAlignment;
@@ -115,6 +116,7 @@ class PinCodeTextField extends StatefulWidget {
     this.errorBorderColor: Colors.red,
     this.onTextChanged,
     this.autofocus: false,
+    this.focusNode,
     this.wrapAlignment: WrapAlignment.start,
     this.pinCodeTextFieldLayoutType: PinCodeTextFieldLayoutType.NORMAL,
     this.textDirection: TextDirection.ltr,
@@ -127,7 +129,7 @@ class PinCodeTextField extends StatefulWidget {
 }
 
 class PinCodeTextFieldState extends State<PinCodeTextField> {
-  FocusNode focusNode = new FocusNode();
+  FocusNode focusNode;
   String text = "";
   int currentIndex = 0;
   List<String> strList = [];
@@ -138,6 +140,8 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
   @override
   void didUpdateWidget(PinCodeTextField oldWidget) {
     super.didUpdateWidget(oldWidget);
+    focusNode = widget.focusNode ?? focusNode;
+
     if (oldWidget.maxLength < widget.maxLength) {
       setState(() {
         currentIndex = text.length;
@@ -191,13 +195,18 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
   @override
   void initState() {
     super.initState();
+    focusNode = widget.focusNode ?? FocusNode();
+
     _initTextController();
     _calculateStrList();
     widget.controller?.addListener(() {
       setState(() {
         _initTextController();
       });
-      widget.onTextChanged(widget.controller.text);
+
+      if (widget.onTextChanged != null) {
+        widget.onTextChanged(widget.controller.text);
+      }
     });
     focusNode.addListener(() {
       setState(() {

--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -246,8 +246,11 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
 
   @override
   void dispose() {
-    focusNode?.dispose();
-    widget.controller?.dispose();
+    if (widget.focusNode == null) {
+      // Only dispose the focus node if it's internal.  Don't dispose the passed
+      // in focus node as it's owned by the parent not this child widget.
+      focusNode?.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
I added the ability to pass in a custom FocusNode so callers could reuse the PIN field after submit.  This same PIN field is really handy for fixed integer inputs that are not pins.

I also fixed an issue that would trigger a stack trace when a text controller was passed in, but the onTextChanged was not.