### PR TITLE
show entire code when pasting

### DIFF
--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -371,8 +371,10 @@ class PinCodeTextFieldState extends State<PinCodeTextField> {
       if (text.length < currentIndex) {
         strList[text.length] = "";
       } else {
-        strList[text.length - 1] =
-            widget.hideCharacter ? widget.maskCharacter : text[text.length - 1];
+        for (int i = currentIndex; i < text.length; i ++) {
+          strList[i] =
+          widget.hideCharacter ? widget.maskCharacter : text[i];
+        }
       }
       currentIndex = text.length;
     });


### PR DESCRIPTION
on iOS device when you start an OTP flow (SMS verification) and you get the SMS, the keyboard will suggest the use the code from the SMS, tapping that suggestion will paste the code in the PinCodeTextField.

the logic works, but visually in this case you will only see the last digit on the last place, and the rest of the fields will remain empty.

this fix makes it so whenever a text is change it will fill all of the input text from the last known position up to the text.length, therefore resolving the above issue