### PR TITLE
Apply default mask character

### DIFF
--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -156,7 +156,7 @@ class PinCodeTextField extends StatefulWidget {
     this.highlightAnimationDuration,
     this.highlightColor: Colors.black,
     this.pinBoxDecoration,
-    this.maskCharacter: " ",
+    this.maskCharacter: "\u25CF",
     this.pinBoxWidth: 70.0,
     this.pinBoxHeight: 70.0,
     this.pinTextStyle,


### PR DESCRIPTION
As per the documentation, the default mask character is "\u25CF" but here, it's an empty space that results in a UI issue as the user may not be aware of the input process.