### PR TITLE
Add support for customizing keyboardAppearance

### DIFF
--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -141,6 +141,7 @@ class PinCodeTextField extends StatefulWidget {
   final WrapAlignment wrapAlignment;
   final TextDirection textDirection;
   final TextInputType keyboardType;
+  final Brightness keyboardAppearance;
   final EdgeInsets pinBoxOuterPadding;
 
   const PinCodeTextField({
@@ -173,6 +174,7 @@ class PinCodeTextField extends StatefulWidget {
     this.wrapAlignment: WrapAlignment.start,
     this.textDirection: TextDirection.ltr,
     this.keyboardType: TextInputType.number,
+    this.keyboardAppearance: Brightness.dark,
     this.pinBoxOuterPadding = const EdgeInsets.symmetric(horizontal: 4.0),
     this.pinBoxColor,
     this.highlightPinBoxColor,
@@ -282,7 +284,6 @@ class PinCodeTextFieldState extends State<PinCodeTextField>
     }
   }
 
-
   void _initTextController() {
     if (widget.controller == null) {
       return;
@@ -377,6 +378,7 @@ class PinCodeTextFieldState extends State<PinCodeTextField>
         focusNode: focusNode,
         controller: widget.controller,
         keyboardType: widget.keyboardType,
+        keyboardAppearance: widget.keyboardAppearance,
         inputFormatters: widget.keyboardType == TextInputType.number
             ? <TextInputFormatter>[WhitelistingTextInputFormatter.digitsOnly]
             : null,
@@ -417,6 +419,7 @@ class PinCodeTextFieldState extends State<PinCodeTextField>
         focusNode: focusNode,
         controller: widget.controller,
         keyboardType: widget.keyboardType,
+        keyboardAppearance: widget.keyboardAppearance,
         inputFormatters: widget.keyboardType == TextInputType.number
             ? <TextInputFormatter>[WhitelistingTextInputFormatter.digitsOnly]
             : null,


### PR DESCRIPTION
This PR adds support for custom keyboardAppearance, the default value of which is Brightness.dark. It will be really helpful if you could merge this.