### PR TITLE
[feature request] Add support for custom height of the currently higlighted pin

### DIFF
--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity mobile apps.'
+  s.description      = <<-DESC
+Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
+                       DESC
+  s.homepage         = 'https://flutter.io'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '8.0'
+  s.vendored_frameworks = 'Flutter.framework'
+end

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/joshuadeguzman/Documents/TOOLS/FLUTTER"
+export "FLUTTER_APPLICATION_PATH=/Users/joshuadeguzman/Documents/DEV/pin_code_text_field/example"
+export "FLUTTER_TARGET=/Users/joshuadeguzman/Documents/DEV/pin_code_text_field/example/lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "OTHER_LDFLAGS=$(inherited) -framework Flutter"
+export "FLUTTER_FRAMEWORK_DIR=/Users/joshuadeguzman/Documents/TOOLS/FLUTTER/bin/cache/artifacts/engine/ios"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "TRACK_WIDGET_CREATION=true"

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,11 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
-		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
-		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -27,8 +23,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */,
-				9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -39,13 +33,11 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
-		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -58,8 +50,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */,
-				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,9 +59,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
@@ -204,7 +192,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -169,7 +169,7 @@ class _MyAppState extends State<MyApp> {
                         .headline4
                         .copyWith(fontFamily: "OpenSans"),
                     highlightPinBoxHeight: 24,
-                    highlightPinBoxWidth: 32,
+                    highlightPinBoxWidth: 40,
                     pinBoxWidth: 16,
                     pinBoxHeight: 16,
                     pinBoxDecoration:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -163,40 +163,25 @@ class _MyAppState extends State<MyApp> {
                   },
                   child: PinCodeTextField(
                     autofocus: true,
-                    controller: controller,
-                    hideCharacter: true,
-                    highlight: true,
-                    highlightColor: Colors.blue,
-                    defaultBorderColor: Colors.black,
-                    hasTextBorderColor: Colors.green,
-                    maxLength: pinLength,
-                    hasError: hasError,
-                    maskCharacter: "😎",
-                    onTextChanged: (text) {
-                      setState(() {
-                        hasError = false;
-                      });
-                    },
-                    onDone: (text) {
-                      print("DONE $text");
-                      print("DONE CONTROLLER ${controller.text}");
-                    },
-                    pinBoxWidth: 50,
-                    pinBoxHeight: 64,
-                    hasUnderline: true,
-                    wrapAlignment: WrapAlignment.spaceAround,
+                    maxLength: 6,
+                    pinTextStyle: Theme.of(context)
+                        .textTheme
+                        .headline4
+                        .copyWith(fontFamily: "OpenSans"),
+                    highlightPinBoxHeight: 24,
+                    highlightPinBoxWidth: 32,
+                    pinBoxWidth: 16,
+                    pinBoxHeight: 16,
                     pinBoxDecoration:
-                        ProvidedPinBoxDecoration.defaultPinBoxDecoration,
-                    pinTextStyle: TextStyle(fontSize: 22.0),
-                    pinTextAnimatedSwitcherTransition:
-                        ProvidedPinBoxTextAnimation.scalingTransition,
-//                    pinBoxColor: Colors.green[100],
-                    pinTextAnimatedSwitcherDuration:
-                        Duration(milliseconds: 300),
-//                    highlightAnimation: true,
-                    highlightAnimationBeginColor: Colors.black,
-                    highlightAnimationEndColor: Colors.white12,
-                    keyboardType: TextInputType.number,
+                        ProvidedPinBoxDecoration.roundedPinBoxDecoration,
+                    highlightColor: Colors.red,
+                    highlightPinBoxColor: Colors.red,
+                    pinBoxColor: Colors.grey.shade300,
+                    defaultBorderColor: Colors.transparent,
+                    hasTextBorderColor: Colors.red,
+                    errorBorderColor: Colors.red,
+                    hasError: false,
+                    hideCharacter: true,
                   ),
                 ),
               ),

--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -580,22 +580,27 @@ class PinCodeTextFieldState extends State<PinCodeTextField>
             duration: Duration(milliseconds: 100),
             curve: Curves.easeInSine,
             key: ValueKey<String>("container$i"),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 8),
-              child: Container(
-                child: Center(child: _animatedTextBox(strList[i], i)),
-                decoration: widget.hasUnderline
-                    ? BoxDecoration(
-                        border: Border(
-                          bottom: BorderSide(
-                            color: borderColor ?? Colors.black,
+            child: Container(
+              decoration: boxDecoration,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 8.0,
+                  horizontal: 8,
+                ),
+                child: Container(
+                  child: Center(child: _animatedTextBox(strList[i], i)),
+                  decoration: widget.hasUnderline
+                      ? BoxDecoration(
+                          border: Border(
+                            bottom: BorderSide(
+                              color: borderColor ?? Colors.black,
+                            ),
                           ),
-                        ),
-                      )
-                    : null,
+                        )
+                      : null,
+                ),
               ),
             ),
-            decoration: boxDecoration,
             width: pinBoxWidth,
             height: pinBoxHeight,
           ),

--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -575,7 +575,10 @@ class PinCodeTextFieldState extends State<PinCodeTextField>
       child: Center(
         child: Padding(
           padding: insets,
-          child: Container(
+          child: AnimatedContainer(
+            // TODO: Can be exposed as well for adaptability
+            duration: Duration(milliseconds: 100),
+            curve: Curves.easeInSine,
             key: ValueKey<String>("container$i"),
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 8),


### PR DESCRIPTION
@LiewJunTung, let me know if this is something you would like to be merged on this plugin.

If this gets prioritized, this should be the next action items we can talk about:

### TODO
- [ ] Exposing the animation curve and duration for the added `AnimatedContainer`
- [ ] Reverting changes made to the demo app back to the original ones (emoji masked inputs) or creating a new example screen

### Changes
- Add `highlightPinBoxHeight`, `highlightPinBoxWidth`, defaults to the default value of the `pinBoxHeight` and `pinBoxWidth` respectively
- Wrap pin with `AnimatedContainer` to animate transition of the size, currently did not include unnecessary changes of the `decoration`

![2020-08-31 15-39-32 2020-08-31 15_40_43](https://user-images.githubusercontent.com/20706361/91695186-56b1a980-eba0-11ea-8ee5-eaccfb24d561.gif)
