### PR TITLE
Fix issue the _onTextChanged function referencing out of bounds values

### DIFF
--- a/lib/pin_code_text_field.dart
+++ b/lib/pin_code_text_field.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/cupertino.dart' show CupertinoTextField;
@@ -439,13 +440,10 @@ class PinCodeTextFieldState extends State<PinCodeTextField>
     }
     setState(() {
       this.text = text;
-      if (text.length < currentIndex) {
-        strList[text.length] = "";
-      } else {
-        for (int i = currentIndex; i < text.length; i++) {
-          strList[i] = widget.hideCharacter ? widget.maskCharacter : text[i];
-        }
-      }
+      strList =
+          (widget.hideCharacter ? widget.maskCharacter * text.length : text)
+              .padRight(max(widget.maxLength - text.length, 0))
+              .split("");
       currentIndex = text.length;
     });
     if (text.length == widget.maxLength) {


### PR DESCRIPTION
The pincode library v1.7.1 seemingly throws an error like this `RangeError (length): Invalid value: Not in inclusive range 0..3: 4. Error thrown Instance of 'ErrorDescription'.` whenever a user presses the backspace button. 

This might be related to another bug I am experiencing in the SDK where the back button removes two characters at once, but that happends in select Text boxes outside of this plugin so I expect it is not related to this plugin.

This PR removes the for loop and index counter and reimplements a function that is similar but does not use index variables in order to avoid these kinds of issues.